### PR TITLE
Use a default mimetype if it can't be recognized correctly

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -55,8 +55,8 @@ try:
   upload_file_mimetype = mimetype_upload_file[0]
 
   if upload_file_mimetype is None:
-    print "could not get mimetype for upload file"
-    sys.exit()
+    print "could not get mimetype for upload file - using the default"
+    upload_file_mimetype = 'application/octet-stream'
 
   upload_file_title =  os.path.basename(upload_file_path)
   

--- a/backup.py
+++ b/backup.py
@@ -40,11 +40,11 @@ try:
   config_file_path = sys.argv[1]
   upload_file_path = sys.argv[2]
 
-  if  os.path.isfile(config_file_path) is False:
+  if os.path.isfile(config_file_path) is False:
     print "not found config file: "+config_file_path
     sys.exit()
 
-  if  os.path.isfile(upload_file_path) is False:
+  if os.path.isfile(upload_file_path) is False:
     print "not found upload file: " + upload_file_path
     sys.exit()
 
@@ -54,7 +54,7 @@ try:
 
   upload_file_mimetype = mimetype_upload_file[0]
 
-  if mimetype_upload_file is None:
+  if upload_file_mimetype is None:
     print "could not get mimetype for upload file"
     sys.exit()
 


### PR DESCRIPTION
The first commit in PR fixes checking if the mimetype has been recognized by `mimetypes.guess_type()` or not. You were checking the `mimetype_upload_file` instead of the `upload_file_mimetype` variable.

The second one changes the behavior of the script - it now uses a deafult `application/octet-stream` mimetype if it can not be recognized. That allows to upload any file with your script.
