### PR TITLE
Add missing colon

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -60,7 +60,7 @@ try:
 
   upload_file_title =  os.path.basename(upload_file_path)
   
-  with open(config_file_path, 'r') as config_file
+  with open(config_file_path, 'r') as config_file:
     config = json.loads(config_file.read())
   
   drive_service = helper.createDriveService(config)


### PR DESCRIPTION
When running the script it would return an 'Invalid Syntax' error.  The with open(config_file_path, 'r') as config_file was missing a colon at the end.